### PR TITLE
Supports ignorePaths option

### DIFF
--- a/README.md
+++ b/README.md
@@ -148,6 +148,9 @@ These are the available config options for the middleware. All is optional excep
 
   // Function to decide log level of the error from `err`
   getErrorLogLevel: (err) => 'error'
+
+  // List of paths to be ignored.
+  ignorePaths: ['/healthcheck', '/readiness']
 }
 ```
 

--- a/README.md
+++ b/README.md
@@ -147,7 +147,7 @@ These are the available config options for the middleware. All is optional excep
   getResponseLogLevel: (ctx) => ctx.state >= 500 ? 'error' : 'info',
 
   // Function to decide log level of the error from `err`
-  getErrorLogLevel: (err) => 'error'
+  getErrorLogLevel: (err) => 'error',
 
   // List of paths to be ignored.
   ignorePaths: ['/healthcheck', '/readiness']

--- a/lib/middleware.js
+++ b/lib/middleware.js
@@ -17,6 +17,7 @@ const utils = require('./utils');
  * @param {function} [options.getRequestLogLevel] - Function to decide log level of the request from `ctx`.
  * @param {function} [options.getResponseLogLevel] - Function to decide log level of the response from `ctx`.
  * @param {function} [options.getErrorLogLevel] - Function to decide log level of the error from `error`.
+ * @param {Array} [options.ignorePaths] - List of paths to be ignored.
  * @return {function} Koa middleware.
  */
 module.exports = (options = {}) => {
@@ -26,7 +27,8 @@ module.exports = (options = {}) => {
     getReqId = () => null,
     getRequestLogLevel = utils.getRequestLogLevel,
     getResponseLogLevel = utils.getResponseLogLevel,
-    getErrorLogLevel = utils.getErrorLogLevel
+    getErrorLogLevel = utils.getErrorLogLevel,
+    ignorePaths = []
   } = options;
   const serializers = {
     ...defaultSerializers,
@@ -40,6 +42,11 @@ module.exports = (options = {}) => {
   debug('Create a middleware');
 
   return async function logging(ctx, next) {
+    if (ignorePaths.includes(ctx.path)) {
+      await next();
+      return;
+    }
+
     // Try to get the request id
     const reqId = getReqId(ctx)
       || ctx.state.reqId


### PR DESCRIPTION
A little PR to improve the configuration.

Before these changes, I did something like this

```js
    this.use(async (ctx, next) => {
      if (ctx.url === '/api') {
        await next();
      } else {
        await logging({
          logger,
          overrideSerializers: false
        })(ctx, next);
      }
    });
```

After I can use this

```js
    this.use(logging({
      logger,
      ignorePaths: ['/api'],
      overrideSerializers: false
    }));
```